### PR TITLE
fix: 修复定时采集角色第二页会提示分类不存在

### DIFF
--- a/application/common/model/Collect.php
+++ b/application/common/model/Collect.php
@@ -1925,7 +1925,7 @@ class Collect extends Base {
                 if($res['code']>1){
                     return $this->error($res['msg']);
                 }
-                $this->actor_data($param,$res );
+                $this->role_data($param,$res );
             }
             mac_echo(lang('model/collect/is_over'));
             die;


### PR DESCRIPTION
定时任务采集角色第二页时会变为采集演员